### PR TITLE
feat: add capture plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
 - [💾 Install](#-install)
 - [🎮 Quick start](#-quick-start)
+- [🔌 Capture Plugin](#-capture-plugin)
 - [🚑 Community & support](#-community--support)
 - [🐋 Docker](#-docker)
 - [🐝 API](#-api)
@@ -92,6 +93,42 @@ For more information on using the available options, run:
 
 ```bash
 stepci-runner --help
+```
+
+**[🔝 back to top](#toc)**
+
+---
+
+## 🔌 Capture Plugin
+
+The `stepci-captured-runner` includes a built-in capture plugin that allows you to transform and store captured values during workflow execution.
+
+### Usage
+
+The capture plugin can be used in your StepCI YAML workflow files to manipulate captured data:
+
+```yaml
+version: "1.1"
+name: Example Workflow
+
+tests:
+  example-test:
+    steps:
+      - name: "Fetch data"
+        http:
+          method: GET
+          url: https://api.example.com/data
+          captures:
+            rawData:
+              jsonpath: $.data
+      
+      - name: "Transform captured data"
+        plugin:
+          id: 'capture-plugin'
+          params:
+            values:
+              processedData: "${{captures.rawData|slice:10}}"
+              customField: "some-value"
 ```
 
 **[🔝 back to top](#toc)**

--- a/capture-plugin.ts
+++ b/capture-plugin.ts
@@ -1,0 +1,29 @@
+import { CapturesStorage } from '@stepci/runner/dist/utils/runner';
+import { StepRunResult } from '@stepci/runner/dist';
+
+export type CapturePlugin = {
+  params: {
+    values: { [key: string]: any };
+  };
+};
+
+export default async function (
+  input: CapturePlugin,
+  captures: CapturesStorage,
+): Promise<StepRunResult> {
+  const stepResult: StepRunResult = {
+    type: 'capture-plugin',
+  }
+
+  for (const key in input.params.values) {
+    if (Object.prototype.hasOwnProperty.call(input.params.values, key)) {
+      const value = input.params.values[key];
+      captures[key] = value;
+    }
+  }
+  
+  return stepResult
+}
+
+
+

--- a/fixtures/capture_plugin.yml
+++ b/fixtures/capture_plugin.yml
@@ -1,0 +1,19 @@
+version: "1.1"
+name: Cached Plugin Workflow
+
+tests:
+  capture-issuer:
+    steps:
+      - name: "Fetch credential offer JSON"
+        http:
+          method: GET
+          url: https://issuer.paradym.pensiondemo.findy.fi/pensioncredential.json
+          captures:
+            type:
+              body: true
+      - name: Transform capture
+        plugin:
+          id: 'capture-plugin'
+          params:
+            values:
+              deeplink:: "${{captures.type|slice:51|url_decode}}"

--- a/fixtures/capture_plugin.yml
+++ b/fixtures/capture_plugin.yml
@@ -16,4 +16,4 @@ tests:
           id: 'capture-plugin'
           params:
             values:
-              deeplink:: "${{captures.type|slice:51|url_decode}}"
+              deeplink: "${{captures.type|slice:51|url_decode}}"

--- a/runner.ts
+++ b/runner.ts
@@ -1,6 +1,8 @@
 import { Command } from 'commander';
 import { runFromFile, runFromYAML, type TestResult, StepResult, WorkflowResult, WorkflowOptions } from '@stepci/runner';
 import fs from 'fs';
+import capturePlugin from './capture-plugin'
+
 
 
 interface CliOptions {
@@ -23,6 +25,16 @@ interface cliError {
 }
 
 const program = new Command();
+const internalPluginName = 'capture-plugin';
+if (require.cache) {
+    require.cache[internalPluginName] = {
+        id: internalPluginName,
+        exports: {
+            default: capturePlugin
+        },
+        loaded: true,
+    } as any;
+}
 
 program
   .option('-p, --path <file>', 'Path to the test file')


### PR DESCRIPTION
`./stepci-captured-runner -p ./fixtures/capture_plugin.yml -h`

```
#capture_plugin.yml
version: "1.1"
name: Cached Plugin Workflow

tests:
  capture-issuer:
    steps:
      - name: "Fetch credential offer JSON"
        http:
          method: GET
          url: https://issuer.paradym.pensiondemo.findy.fi/pensioncredential.json
          captures:
            type:
              body: true
      - name: Transform capture
        plugin:
          id: 'capture-plugin'
          params:
            values:
              deeplink:: "${{captures.type|slice:51|url_decode}}"
```
returns:
```
✅ Workflow PASSED!

🧪 Tests: 1 | ✅ Passed: 1 | ❌ Failed: 0
🚶 Steps: 2 | ✅ Passed: 2 | ❌ Failed: 0

📦 Captures:
  - type: "https://paradym.id/invitation?credential_offer_uri=https%3A%2F%2Fparadym.id%2Finvitation%2F582c8ed7-2b5c-461c-b5f7-7ad299205757%2Foffers%2F25baca05-c0fc-4521-8240-ad4ed08eff92%3Fraw%3Dtrue"
  - deeplink:: "https://paradym.id/invitation/582c8ed7-2b5c-461c-b5f7-7ad299205757/offers/25baca05-c0fc-4521-8240-ad4ed08eff92?raw=true"

📝 Details:
Workflow passed

🎉 All done! Your workflow succeeded.
```